### PR TITLE
Change the default values for user-email and user-name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,11 @@ inputs:
   user-name:
     description: Git commit user name
     required: false
-    default: github-actions
+    default: "github-actions[bot]"
   user-email:
     description: Git commit user email
     required: false
-    default: github-actions@github.com
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
In order to get an appropriate GitHub Actions Bot annotation, we should set right email address as well as user name for GitHub Actions bot user.

I followed the code below.

https://github.com/super-linter/super-linter/blob/d33107802b1ecab6ffc4146ac2d5644c72a673e4/.github/workflows/cd.yml#L256-L257